### PR TITLE
Adds the possibility to alter the class of an existing instance.

### DIFF
--- a/src/Mouf/MoufManager.php
+++ b/src/Mouf/MoufManager.php
@@ -1957,6 +1957,21 @@ class MoufManager implements ContainerInterface {
 		$this->setInstanceAnonymousness($name, true);
 		return $this->getInstanceDescriptor($name);
 	}
+
+    /**
+     * Alters the class of instance $instanceName.
+     * Useful for migration purposes.
+     *
+     * @param string $instanceName
+     * @param string $className
+     * @throws MoufInstanceNotFoundException
+     */
+	public function alterClass($instanceName, $className) {
+        if (!isset($this->declaredInstances[$instanceName])) {
+            throw new MoufInstanceNotFoundException("Unable to find instance '".$instanceName."'.");
+        }
+        $this->declaredInstances[$instanceName]["class"] = $className;
+    }
 	
 	/**
 	 * A list of descriptors.


### PR DESCRIPTION
This is useful for migration purposes (when one class is migrated from one name to another for instance), or for subclassing (when one instance becomes an instance of a subclass)