### PR TITLE
Fixing saving of the fetchFromEnv parameter in config

### DIFF
--- a/src-dev/Mouf/Controllers/ConfigController.php
+++ b/src-dev/Mouf/Controllers/ConfigController.php
@@ -195,7 +195,7 @@ class ConfigController extends Controller {
  	 * @param string $type
  	 * @param string $selfedit
 	 */
-	public function registerConstant($name, $comment, $type, $defaultvalue = "", $value = "", $selfedit = "false") {
+	public function registerConstant($name, $comment, $type, $defaultvalue = "", $value = "", $selfedit = "false", $fetchFromEnv = "false") {
 		$this->selfedit = $selfedit;
 		
 		if ($selfedit == "true") {
@@ -224,7 +224,7 @@ class ConfigController extends Controller {
 			}
 		}
 		
-		$this->configManager->registerConstant($name, $type, $defaultvalue, $comment);
+		$this->configManager->registerConstant($name, $type, $defaultvalue, $comment, $fetchFromEnv === 'true');
 		$this->moufManager->rewriteMouf();
 		
 		// Now, let's write the constant for our environment:


### PR DESCRIPTION
The checkbox "fetch from environement" in the config page was not taken into account.
This PR fixes this behaviour.